### PR TITLE
Fix minor header comment mistakes

### DIFF
--- a/src/memref/ops.rs
+++ b/src/memref/ops.rs
@@ -502,7 +502,8 @@ impl Printable for LoadOp {
         let indices = self.get_indices(ctx);
         write!(
             f,
-            "{} {}[{}] : {}",
+            "{} = {} {}[{}] : {}",
+            self.get_result(ctx).disp(ctx),
             Self::get_opid_static(),
             memref.disp(ctx),
             iter_with_sep(indices.iter(), printable::ListSeparator::CharSpace(',')).disp(ctx),

--- a/src/tensor/bufferize.rs
+++ b/src/tensor/bufferize.rs
@@ -162,14 +162,14 @@ impl Verify for Alias {
 /// [Op]s implementing this can participate in bufferization.
 #[op_interface]
 pub trait BufferizableOpInterface {
-    /// Return true if this operand bufferizes to a memory read of that operand.
+    /// Return true if this operation bufferizes to a memory read of operand `opd`.
     /// It will only be called on operands that have a tensor type.
     ///
     /// It is always safe to return `true`, but that may introduce unnecessary
     /// allocations and / or copies.
     fn operand_bufferizes_to_memory_read(&self, ctx: &Context, opd: Use<Value>) -> bool;
 
-    /// Return true if this operand bufferizes to a memory write of that operand.
+    /// Return true if this operation bufferizes to a memory write of operand `opd`.
     /// It will only be called on operands that have a tensor type.
     ///
     /// It is always safe to return `true`, but that may introduce unnecessary
@@ -246,7 +246,7 @@ pub trait BufferizableOpInterface {
 pub trait MemrefAllocOpInterface:
     OneResultInterface + ResultNOfType<0, RankedMemrefType> + ToCFDialect
 {
-    /// Create a new [Self] to allocate a buffer for `tensor_ty` with given `dynamic_sizes`.
+    /// Create a new [Self] to allocate a buffer for `memref_ty` with given `dynamic_sizes`.
     /// Any IR static information that may be needed can be passed via `static_info`.
     fn try_new(
         ctx: &mut Context,

--- a/tests/tensor_conversions.rs
+++ b/tests/tensor_conversions.rs
@@ -1231,7 +1231,7 @@ fn test_tensor_reshape_to_memref_cf_from_rust() {
                 v11 = memref.reshape arg_v1 : memref.ranked <3x2 : builtin.integer i64> !3;
                 i_idx_v4 = index.from_integer i_res_v9 : index.index  !4;
                 j_idx_v6 = index.from_integer j_res_v10 : index.index  !5;
-                memref.load v11[i_idx_v4, j_idx_v6] : builtin.integer i64 !6;
+                v12 = memref.load v11[i_idx_v4, j_idx_v6] : builtin.integer i64 !6;
                 llvm.return v12 !7
             } !8
         }"#]].assert_eq(&after_tensor_to_memref);


### PR DESCRIPTION
While reading through the code, I encountered a few comments that seemed to be mistaken.

This PR contains what I believe to be the corrected versions.

I also updated the memref.LoadOp operation's Printable implementation to display its result value. 